### PR TITLE
fix(react-sdk): props theme change not working

### DIFF
--- a/packages/react-cusdis/src/ReactCusdis.tsx
+++ b/packages/react-cusdis/src/ReactCusdis.tsx
@@ -37,6 +37,11 @@ export function ReactCusdis(props: {
     props.lang
   ])
 
+  React.useEffect(() => {
+    // @ts-expect-error
+    window.CUSDIS?.setTheme(props.attrs.theme)
+  }, [props.attrs.theme])
+
   return (
     <>
       <div


### PR DESCRIPTION
When I'm using React Componet, and dynamic change props theme, cusdis doesn't change the theme.
```tsx
        <CusdisComponent
          lang={fetchCusdisLang()}
          attrs={{
            // ...others
            theme: isDark ? 'dark' : 'light'
          }}
        />
```

So, I think that I can use effect to dynamic call event setTheme to fix this bug.