### PR TITLE
Adding React v18 to peer dependencies

### DIFF
--- a/packages/react-cusdis/package.json
+++ b/packages/react-cusdis/package.json
@@ -12,8 +12,8 @@
     "prepublish": "npm run build"
   },
   "peerDependencies": {
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@types/node": "^14.14.41",


### PR DESCRIPTION
Adds support to React v18 projects.

```
npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: nobelium@1.3.0
npm ERR! Found: react@18.3.1
npm ERR! node_modules/react
npm ERR!   react@"^18.2.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^17.0.0" from react-cusdis@2.1.3
npm ERR! node_modules/react-cusdis
npm ERR!   react-cusdis@"^2.1.3" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! 
npm ERR! For a full report see:
npm ERR! /Users/xxxx/.npm/_logs/2024-06-13T06_15_42_660Z-eresolve-report.txt

npm ERR! A complete log of this run can be found in: /Users/xxxx/.npm/_logs/2024-06-13T06_15_42_660Z-debug-0.log
```